### PR TITLE
fix: republish all packages with clean exports

### DIFF
--- a/.changeset/republish-clean-exports.md
+++ b/.changeset/republish-clean-exports.md
@@ -1,0 +1,17 @@
+---
+'@orchestr8/schema': patch
+'@orchestr8/logger': patch
+'@orchestr8/resilience': patch
+'@orchestr8/core': patch
+'@orchestr8/cli': patch
+'@orchestr8/agent-base': patch
+---
+
+fix: republish all packages with clean exports
+
+Remove development export conditions from all published packages to ensure
+external consumers receive clean, production-ready package.json files without
+development-specific export mappings that could cause module resolution issues.
+
+The prepublishOnly scripts automatically strip development exports during
+npm publishing while preserving them for fast local development workflow.


### PR DESCRIPTION
## Summary

Republish all packages with patch bumps to ensure clean exports without development fields.

## Problem

While the published packages on npm correctly have development export fields stripped by the prepublishOnly script, we want to ensure all packages are republished with clean exports to maintain consistency.

## Changes Made

- Added changeset for all packages (`@orchestr8/schema`, `@orchestr8/logger`, `@orchestr8/resilience`, `@orchestr8/core`, `@orchestr8/cli`, `@orchestr8/agent-base`)
- Patch bump will trigger the prepublishOnly script to remove development exports during publishing
- All packages will be published with production-ready package.json files

## Test Plan

- [x] All tests passing (486+ tests)
- [x] pnpm check passes
- [x] Changeset created and committed
- [ ] GitHub Actions will handle versioning and publishing

The prepublishOnly scripts automatically strip development exports during npm publishing while preserving them for fast local development workflow.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured published packages use clean, production-ready exports to prevent module resolution issues for consumers.

* **Chores**
  * Patch republish of @orchestr8/schema, @orchestr8/logger, @orchestr8/resilience, @orchestr8/core, @orchestr8/cli, and @orchestr8/agent-base with cleaned exports. Dev-only export conditions are stripped during publish. No changes to public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->